### PR TITLE
Change env var prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.0](https://github.com/salesforcecli/plugin-info/compare/v1.0.0...v1.1.0) (2021-11-22)
+
+
+### Features
+
+* initial setup and release notes fetch ([d258d91](https://github.com/salesforcecli/plugin-info/commit/d258d91cf3f781c0afbc4f8b3c776cd4fd0085ef))
+* parse and render release notes ([f5e3398](https://github.com/salesforcecli/plugin-info/commit/f5e3398f14e74aa1f83fa308c9601f1b770afcae))
+* parse release notes ([83f0a47](https://github.com/salesforcecli/plugin-info/commit/83f0a47d5e54e0e0cacace1f3bc12ad757aa6e38))
+
+
+### Bug Fixes
+
+* no more partial version match. updates footer ([010c4f3](https://github.com/salesforcecli/plugin-info/commit/010c4f38e963e416f57032db9578a28b26ed2b08))
+* pin typescript ([c02bd4e](https://github.com/salesforcecli/plugin-info/commit/c02bd4e0beb4b686e5a3e6ced866e97d4d61ed88))
+* switch from axios to got, added tests ([ef74275](https://github.com/salesforcecli/plugin-info/commit/ef74275517f2305e705e9f21d62f9f916a17471a))
+* test for Windows ([16db159](https://github.com/salesforcecli/plugin-info/commit/16db159ca3fb64a51f0076881bea5df37e4edce9))
+
 ## 1.0.0 (2021-10-12)

--- a/README.md
+++ b/README.md
@@ -74,43 +74,39 @@ sfdx plugins
 ## Commands
 
 <!-- commands -->
-* [`sfdx hello:org [-n <string>] [-f] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-helloorg--n-string--f--v-string--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+* [`sfdx info:releasenotes:display [-v <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-inforeleasenotesdisplay--v-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 
-## `sfdx hello:org [-n <string>] [-f] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+## `sfdx info:releasenotes:display [-v <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
-print a greeting and your org IDs
+display Salesforce CLI release notes on the command line
 
 ```
 USAGE
-  $ sfdx hello:org [-n <string>] [-f] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel 
+  $ sfdx info:releasenotes:display [-v <string>] [--json] [--loglevel 
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
-  -f, --force                                                                       example boolean flag
-  -n, --name=name                                                                   name to print
-
-  -u, --targetusername=targetusername                                               username or alias for the target
-                                                                                    org; overrides default target org
-
-  -v, --targetdevhubusername=targetdevhubusername                                   username or alias for the dev hub
-                                                                                    org; overrides default dev hub org
-
-  --apiversion=apiversion                                                           override the api version used for
-                                                                                    api requests made by this command
+  -v, --version=version                                                             CLI version or tag for which to
+                                                                                    display release notes
 
   --json                                                                            format output as json
 
   --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for
                                                                                     this command invocation
 
+ALIASES
+  $ sfdx whatsnew
+
 EXAMPLES
-  $ sfdx hello:org --targetusername myOrg@example.com --targetdevhubusername devhub@org.com
-     Hello world! This is org: MyOrg and I will be around until Tue Mar 20 2018!
-     My hub org id is: 00Dxx000000001234
-  
-  $ sfdx hello:org --name myname --targetusername myOrg@example.com
-     Hello myname! This is org: MyOrg and I will be around until Tue Mar 20 2018!
+  Display release notes for the currently installed CLI version:
+     sfdx info:releasenotes:display
+
+  Display release notes for CLI version 7.120.0:
+     sfdx info:releasenotes:display --version 7.120.0
+
+  Display release notes for the CLI version that corresponds to a tag (stable, stable-rc, latest, latest-rc, rc):
+     sfdx info:releasenotes:display --version latest
 ```
 
-_See code: [src/commands/hello/org.ts](https://github.com/salesforcecli/plugin-template/blob/v1.0.0/src/commands/hello/org.ts)_
+_See code: [src/commands/info/releasenotes/display.ts](https://github.com/salesforcecli/plugin-info/blob/v1.1.0/src/commands/info/releasenotes/display.ts)_
 <!-- commandsstop -->

--- a/src/commands/info/releasenotes/display.ts
+++ b/src/commands/info/releasenotes/display.ts
@@ -52,7 +52,9 @@ export default class Display extends SfdxCommand {
   public async run(): Promise<void> {
     const env = new Env();
 
-    if (env.getBoolean(HIDE_NOTES)) {
+    const isHook = !!this.flags.hook;
+
+    if (env.getBoolean(HIDE_NOTES) && isHook) {
       // We don't ever want to exit the process for info:releasenotes:display (whatsnew)
       // In most cases we will log a message, but here we only trace log in case someone using stdout of the update command
       this.logger.trace(`release notes disabled via env var: ${HIDE_NOTES}`);
@@ -60,8 +62,6 @@ export default class Display extends SfdxCommand {
 
       return;
     }
-
-    const isHook = !!this.flags.hook;
 
     try {
       const installedVersion = this.config.pjson.version;

--- a/src/commands/info/releasenotes/display.ts
+++ b/src/commands/info/releasenotes/display.ts
@@ -22,8 +22,8 @@ import { parseReleaseNotes } from '../../../shared/parseReleaseNotes';
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
 
-const HIDE_NOTES = 'PLUGIN_INFO_HIDE_RELEASE_NOTES';
-const HIDE_FOOTER = 'PLUGIN_INFO_HIDE_FOOTER';
+const HIDE_NOTES = 'SFDX_HIDE_RELEASE_NOTES';
+const HIDE_FOOTER = 'SFDX_HIDE_RELEASE_NOTES_FOOTER';
 
 // Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
 // or any library that is using the messages framework can also be loaded this way.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,4 +5,4 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export const PLUGIN_INFO_GET_TIMEOUT = (process.env.PLUGIN_INFO_GET_TIMEOUT || 3000) as number;
+export const SFDX_RELEASE_NOTES_TIMEOUT = (process.env.SFDX_RELEASE_NOTES_TIMEOUT || 3000) as number;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,4 +5,4 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export const SFDX_RELEASE_NOTES_TIMEOUT = (process.env.SFDX_RELEASE_NOTES_TIMEOUT || 3000) as number;
+export const SFDX_RELEASE_NOTES_TIMEOUT = (process.env.SFDX_RELEASE_NOTES_TIMEOUT ?? 3000) as number;

--- a/src/shared/getDistTagVersion.ts
+++ b/src/shared/getDistTagVersion.ts
@@ -6,7 +6,7 @@
  */
 
 import got from 'got';
-import { PLUGIN_INFO_GET_TIMEOUT } from '../constants';
+import { SFDX_RELEASE_NOTES_TIMEOUT } from '../constants';
 
 export type DistTagJson = {
   latest: string;
@@ -16,7 +16,7 @@ export type DistTagJson = {
 const getDistTagVersion = async (url: string, distTag: string): Promise<string> => {
   // TODO: Could use npm instead here. That way private cli repos could auth with .npmrc
   // -- could utilize this: https://github.com/salesforcecli/plugin-trust/blob/0393b906a30e8858816625517eda5db69377c178/src/lib/npmCommand.ts
-  const options = { timeout: PLUGIN_INFO_GET_TIMEOUT };
+  const options = { timeout: SFDX_RELEASE_NOTES_TIMEOUT };
 
   const body = await got(url, options).json<DistTagJson>();
 

--- a/src/shared/getReleaseNotes.ts
+++ b/src/shared/getReleaseNotes.ts
@@ -7,7 +7,7 @@
 
 import got from 'got';
 import { major } from 'semver';
-import { PLUGIN_INFO_GET_TIMEOUT } from '../constants';
+import { SFDX_RELEASE_NOTES_TIMEOUT } from '../constants';
 
 const getReleaseNotes = async (base: string, filename: string, version: string): Promise<string> => {
   const majorVersion = major(version);
@@ -15,7 +15,7 @@ const getReleaseNotes = async (base: string, filename: string, version: string):
   const rawBase = base.replace('github.com', 'raw.githubusercontent.com').replace('/blob/', '/').replace('/tree/', '/');
 
   const options = {
-    timeout: PLUGIN_INFO_GET_TIMEOUT,
+    timeout: SFDX_RELEASE_NOTES_TIMEOUT,
     throwHttpErrors: false,
   };
 

--- a/test/commands/info/releasenotes/display.test.ts
+++ b/test/commands/info/releasenotes/display.test.ts
@@ -66,8 +66,8 @@ describe('info:releasenotes:display', () => {
     oclifConfigStub.root = '/root/path';
 
     getBooleanStub = stubMethod(sandbox, Env.prototype, 'getBoolean');
-    getBooleanStub.withArgs('PLUGIN_INFO_HIDE_RELEASE_NOTES').returns(false);
-    getBooleanStub.withArgs('PLUGIN_INFO_HIDE_FOOTER').returns(false);
+    getBooleanStub.withArgs('SFDX_HIDE_RELEASE_NOTES').returns(false);
+    getBooleanStub.withArgs('SFDX_HIDE_RELEASE_NOTES_FOOTER').returns(false);
 
     getInfoConfigStub = stubMethod(sandbox, getInfoConfig, 'getInfoConfig').returns(mockInfoConfig);
     getReleaseNotesStub = stubMethod(sandbox, getReleaseNotes, 'getReleaseNotes').returns('## Release notes for 3.3.3');
@@ -81,7 +81,7 @@ describe('info:releasenotes:display', () => {
   });
 
   it('allows you to suppress release notes output with env var', async () => {
-    getBooleanStub.withArgs('PLUGIN_INFO_HIDE_RELEASE_NOTES').returns(true);
+    getBooleanStub.withArgs('SFDX_HIDE_RELEASE_NOTES').returns(true);
 
     await runDisplayCmd([]);
 
@@ -211,7 +211,7 @@ describe('info:releasenotes:display', () => {
   });
 
   it('hides footer if env var is set', async () => {
-    getBooleanStub.withArgs('PLUGIN_INFO_HIDE_FOOTER').returns(true);
+    getBooleanStub.withArgs('SFDX_HIDE_RELEASE_NOTES_FOOTER').returns(true);
 
     await runDisplayCmd(['--hook']);
 

--- a/test/commands/info/releasenotes/display.test.ts
+++ b/test/commands/info/releasenotes/display.test.ts
@@ -81,12 +81,22 @@ describe('info:releasenotes:display', () => {
   });
 
   it('allows you to suppress release notes output with env var', async () => {
+    // This env var is only honored when the --hook flag is passed.
+    // If someone is running the command directly, we show notes regardless.
+    getBooleanStub.withArgs('SFDX_HIDE_RELEASE_NOTES').returns(true);
+
+    await runDisplayCmd(['--hook']);
+
+    expect(uxLogStub.called).to.be.false;
+    expect(uxWarnStub.called).to.be.false;
+  });
+
+  it('ignores hide release notes env var if running command directly (without --hook)', async () => {
     getBooleanStub.withArgs('SFDX_HIDE_RELEASE_NOTES').returns(true);
 
     await runDisplayCmd([]);
 
-    expect(uxLogStub.called).to.be.false;
-    expect(uxWarnStub.called).to.be.false;
+    expect(uxLogStub.args[0][0]).to.contain('## Release notes for 3.3.3');
   });
 
   it('calls getInfoConfig with config root', async () => {

--- a/test/shared/getReleaseNotes.test.ts
+++ b/test/shared/getReleaseNotes.test.ts
@@ -12,7 +12,7 @@ import * as SinonChai from 'sinon-chai';
 import * as semver from 'semver';
 import { stubMethod, spyMethod } from '@salesforce/ts-sinon';
 import { getReleaseNotes } from '../../src/shared/getReleaseNotes';
-import { PLUGIN_INFO_GET_TIMEOUT } from '../../src/constants';
+import { SFDX_RELEASE_NOTES_TIMEOUT } from '../../src/constants';
 
 chaiUse(SinonChai);
 
@@ -41,7 +41,7 @@ describe('getReleaseNotes tests', () => {
     version = '1.2.3';
     filename = 'readme.md';
     options = {
-      timeout: PLUGIN_INFO_GET_TIMEOUT,
+      timeout: SFDX_RELEASE_NOTES_TIMEOUT,
       throwHttpErrors: false,
     };
     versionedResponse = {


### PR DESCRIPTION
### What does this PR do?
Changes env var prefix to `SFDX` based on [this conversation](https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1637683268250800)

### What issues does this PR fix or reference?
[@W-10237459@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10237459)
