### PR TITLE
Do not render emoji

### DIFF
--- a/src/commands/info/releasenotes/display.ts
+++ b/src/commands/info/releasenotes/display.ts
@@ -83,7 +83,7 @@ export default class Display extends SfdxCommand {
       const tokens = parseReleaseNotes(releaseNotes, version, releaseNotesPath);
 
       marked.setOptions({
-        renderer: new TerminalRenderer(),
+        renderer: new TerminalRenderer({ emoji: false }),
       });
 
       this.ux.log(marked.parse(`# Release notes for '${this.config.bin}':`));

--- a/test/commands/info/releasenotes/display.test.ts
+++ b/test/commands/info/releasenotes/display.test.ts
@@ -111,6 +111,14 @@ describe('info:releasenotes:display', () => {
     expect(getInfoConfigStub.args[0][0]).to.equal('/root/path');
   });
 
+  it('does not render emoji', async () => {
+    getReleaseNotesStub.returns('## 3.3.3 :tada:');
+
+    await runDisplayCmd([]);
+
+    expect(uxLogStub.args[1][0]).to.contain('## 3.3.3 :tada:');
+  });
+
   it('throws an error if info config lookup fails', async () => {
     getInfoConfigStub.throws(new Error('info config error'));
 


### PR DESCRIPTION
### What does this PR do?
Marked terminal renders emoji by default. Normally wouldn't matter but our command structure causes problems 😛 

Before:
<img width="487" alt="Screen Shot 2021-12-06 at 7 20 56 PM" src="https://user-images.githubusercontent.com/1715111/144950455-353fc679-1f3e-44e4-9788-c384aa2903d1.png">

After:
<img width="520" alt="Screen Shot 2021-12-06 at 7 43 03 PM" src="https://user-images.githubusercontent.com/1715111/144950548-b38d8656-4572-457b-9e23-5584ae0c44fa.png">

### What issues does this PR fix or reference?
[@W-10260114@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10260114)