### PR TITLE
Sm/force

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,5 +1,10 @@
 [
   {
+    "command": "force",
+    "plugin": "@salesforce/plugin-info",
+    "flags": ["json", "loglevel"]
+  },
+  {
     "command": "info:releasenotes:display",
     "plugin": "@salesforce/plugin-info",
     "flags": ["hook", "json", "loglevel", "version"]

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
     "@oclif/config": "^1",
+    "@oclif/plugin-help": "^3.3.1",
     "@salesforce/command": "^4.1.5",
     "@salesforce/core": "^2.29.0",
     "@salesforce/kit": "^1.5.17",

--- a/src/commands/force.ts
+++ b/src/commands/force.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// This is a doc command
+/* istanbul ignore file */
+
+import { SfdxCommand } from '@salesforce/command';
+import got from 'got';
+import { Help } from '@oclif/plugin-help';
+import * as ProxyAgent from 'proxy-agent';
+import { getProxyForUrl } from 'proxy-from-env';
+
+const getAsciiSignature = (apiVersion: string): string => `
+                 DX DX DX
+             DX DX DX DX DX DX          DX DX DX
+          DX DX DX      DX DX DX    DX DX DX DX DX DX
+        DX DX              DX DX DX DX DX     DX DX DX
+       DX DX                 DX DX DX             DX DX    DX DX DX
+      DX DX                    DX DX                DX DX DX DX DX DX DX
+     DX DX                                          DX DX DX       DX DX DX
+     DX DX                                            DX             DX DX DX
+      DX DX                                                              DX DX
+      DX DX                                                               DX DX
+       DX DX                                                              DX DX
+     DX DX                                                                 DX DX
+   DX DX                                                                   DX DX
+ DX DX                                                                     DX DX
+DX DX                                                                     DX DX
+DX DX                                                                    DX DX
+DX DX                                                                   DX DX
+ DX DX                                                    DX          DX DX
+ DX DX                                                  DX DX DX DX DX DX
+  DX DX                                                 DX DX DX DX DX
+    DX DX DX   DX DX                     DX           DX DX
+       DX DX DX DX DX                   DX DX DX DX DX DX
+          DX DX  DX DX                  DX DX DX DX DX
+                  DX DX              DX DX
+                    DX DX DX     DX DX DX
+                      DX DX DX DX DX DX                     v${apiVersion}
+                          DX DX DX
+
+* Salesforce CLI Release Notes: https://github.com/forcedotcom/cli/tree/main/releasenotes
+* Salesforce DX Setup Guide: https://sfdc.co/sfdx_setup_guide
+* Salesforce DX Developer Guide: https://sfdc.co/sfdx_dev_guide
+* Salesforce CLI Command Reference: https://sfdc.co/sfdx_cli_reference
+* Salesforce Extensions for VS Code: https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode
+`;
+
+const getCurrentApiVersion = async (): Promise<string> => {
+  const url = 'https://mdcoverage.secure.force.com/services/apexrest/report';
+  return `${(
+    JSON.parse(
+      (
+        await got(url, {
+          agent: { https: ProxyAgent(getProxyForUrl(url)) },
+        })
+      ).body
+    ) as {
+      versions: { selected: number };
+    }
+  ).versions.selected.toString()}.0`;
+};
+
+export class ForceCommand extends SfdxCommand {
+  public static readonly hidden = true;
+
+  public async run(): Promise<{ apiVersion: string }> {
+    const apiVersion = await getCurrentApiVersion();
+    this.ux.log(getAsciiSignature(apiVersion));
+    return { apiVersion };
+  }
+
+  // overrides the help so that it shows the help for the `force` topic and not "help" for this command
+  protected _help(): never {
+    const help = new Help(this.config);
+    // We need to include force in the args for topics to be shown
+    help.showHelp(process.argv.slice(2));
+    return this.exit(0);
+  }
+}

--- a/src/commands/force.ts
+++ b/src/commands/force.ts
@@ -13,6 +13,7 @@ import got from 'got';
 import { Help } from '@oclif/plugin-help';
 import * as ProxyAgent from 'proxy-agent';
 import { getProxyForUrl } from 'proxy-from-env';
+import { ConfigAggregator } from '@salesforce/core';
 
 const getAsciiSignature = (apiVersion: string): string => `
                  DX DX DX
@@ -51,6 +52,10 @@ DX DX                                                                   DX DX
 `;
 
 const getCurrentApiVersion = async (): Promise<string> => {
+  const apiFromConfig = ConfigAggregator.getValue('apiVersion').value as string;
+  if (apiFromConfig) {
+    return apiFromConfig;
+  }
   const url = 'https://mdcoverage.secure.force.com/services/apexrest/report';
   return `${(
     JSON.parse(

--- a/test/nuts/blank.nut.ts
+++ b/test/nuts/blank.nut.ts
@@ -1,6 +1,0 @@
-/*
- * Copyright (c) 2021, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */

--- a/test/nuts/force.nut.ts
+++ b/test/nuts/force.nut.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+
+import { TestSession, execCmd } from '@salesforce/cli-plugins-testkit';
+
+describe('force command', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        name: 'forceNut',
+      },
+    });
+  });
+  it('returns an apiVersion in JSON', () => {
+    const result = execCmd<{ apiVersion: string }>('force --json', { ensureExitCode: 0 }).jsonOutput.result;
+    expect(result).to.be.an('object').that.has.all.keys('apiVersion');
+    expect(result.apiVersion).to.match(/^\d{2,}\.0$/);
+    expect(parseInt(result.apiVersion, 10)).to.be.greaterThan(53);
+  });
+  it('executes the cloud/links without JSON', () => {
+    const result = execCmd('force', { ensureExitCode: 0 }).shellOutput as string;
+    expect(result).to.include('Salesforce CLI Release Notes');
+  });
+
+  after(async () => {
+    await session.clean();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@oclif/config": ["node_modules/@oclif/config"]
+    }
   },
   "include": ["./src/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,6 +586,23 @@
     widest-line "^2.0.1"
     wrap-ansi "^4.0.0"
 
+"@oclif/plugin-help@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-3.3.1.tgz#36adb4e0173f741df409bb4b69036d24a53bfb24"
+  integrity sha512-QuSiseNRJygaqAdABYFWn/H1CwIZCp9zp/PLid6yXvy6VcQV7OenEFF5XuYaCvSARe2Tg9r8Jqls5+fw1A9CbQ==
+  dependencies:
+    "@oclif/command" "^1.8.15"
+    "@oclif/config" "1.18.2"
+    "@oclif/errors" "1.3.5"
+    "@oclif/help" "^1.0.1"
+    chalk "^4.1.2"
+    indent-string "^4.0.0"
+    lodash "^4.17.21"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    widest-line "^3.1.0"
+    wrap-ansi "^6.2.0"
+
 "@oclif/screen@^1.0.3", "@oclif/screen@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"


### PR DESCRIPTION
### What does this PR do?
migrate `sfdx force`
since the CLI doesn't "maintain" an API version the way toolbelt did, we use the coverage report's api version.  The main use case for this command I saw around github was people getting the apiVersion from the `--json`.
add a NUT because since there's no org involved, it's easier and nearly as fast to write a NUT than to mock out `got`, plus we'll know if the coverage report ever relocates!

### Testing Notes

For reasons beyond my comprehension, oclif help doesn't work the same for ./bin/run as for a linked plugin from the executable.

So `./bin/run force --help` will yield the command help (which we don't want) so you have to test this by linking the plugin `sfdx plugins:link .` from this dir, and then running `sfdx force --help` which should yield the `force` topic's help.

Otherwise, make sure the json output is identical.

### What issues does this PR fix or reference?
[@W-10657367@](https://gus.lightning.force.com/a07EE00000m242IYAQ)