### PR TITLE
fix: support sf cli

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -62,9 +62,8 @@ export class Diagnostics {
    * Checks to see if the running version of the CLI is the latest.
    */
   public async outdatedCliVersionCheck(): Promise<void> {
-    const cliVersionArray = this.diagnosis.versionDetail.cliVersion.split('/');
-    const cliName = cliVersionArray[0];
-    const cliVersion = cliVersionArray[1];
+    const cliName = this.config.name;
+    const cliVersion = this.config.version;
 
     return new Promise<void>((resolve) => {
       const testName = 'using latest or latest-rc CLI version';

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -46,6 +46,8 @@ describe('Diagnostics', () => {
     lifecycleEmitSpy = spyMethod(sandbox, lifecycle, 'emit');
     oclifConfigStub = fromStub(
       stubInterface<Config>(sandbox, {
+        name: 'sfdx-cli',
+        version: '7.160.0',
         pjson: {
           engines: {
             node: 'node-v16.17.0',


### PR DESCRIPTION
### What does this PR do?
changes how the cli name and version are used in the outdatedCliVersionCheck diagnostic test.  rather than parsing it from the cliVersion string, just use the oclif config object.

### What issues does this PR fix or reference?
@W-11862622@