### PR TITLE
style: linter rule for floating promises

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -17,7 +17,7 @@ import { ProxyAgent } from 'proxy-agent';
 import { Doctor as SFDoctor, SfDoctor, SfDoctorDiagnosis } from '../doctor.js';
 import { DiagnosticStatus } from '../diagnostics.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-info', 'doctor');
 
 export default class Doctor extends SfCommand<SfDoctorDiagnosis> {
@@ -97,7 +97,7 @@ export default class Doctor extends SfCommand<SfDoctorDiagnosis> {
           this.tasks.push(this.config.runHook(eventName, { doctor: this.doctor }));
         }
       });
-      this.tasks = [...this.tasks, ...this.doctor.diagnose()];
+      this.doctor.diagnose().map((p) => this.tasks.push(p));
     }
 
     await Promise.all(this.tasks);


### PR DESCRIPTION
### What does this PR do?
satisfy the linter.  It *might* have been possible to get the default unhandled promise exception if one of these failed.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/eslint-config-salesforce-typescript/actions/runs/7390721054/job/20106195808?pr=210