### PR TITLE
fix: omit _commandIDs and rootPlugin from doctor diagnosis

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -48,7 +48,7 @@ export interface SfDoctorDiagnosis {
   logFilePaths: string[];
 }
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-info', 'doctor');
 
 const PINNED_SUGGESTIONS = [
@@ -76,7 +76,14 @@ export class Doctor implements SfDoctor {
     __cliConfig = config;
     const sfdxEnvVars = new Env().entries().filter((e) => e[0].startsWith('SFDX_'));
     const sfEnvVars = new Env().entries().filter((e) => e[0].startsWith('SF_'));
-    const cliConfig = omit(config, ['plugins', 'pjson', 'userPJSON', 'options']) as CliConfig;
+    const cliConfig = omit(config, [
+      'plugins',
+      'pjson',
+      'userPJSON',
+      'options',
+      '_commandIDs',
+      'rootPlugin',
+    ]) as CliConfig;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     cliConfig.nodeEngine = config.pjson.engines.node as string;
 

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -55,6 +55,8 @@ describe('Doctor Class', () => {
     },
     plugins: [{ name: '@salesforce/plugin-org' }, { name: '@salesforce/plugin-source' }, { name: 'salesforce-alm' }],
     versionDetails: getVersionDetailStub(),
+    _commandIDs: ['first', 'second'], // this should not be included in the diagnosis
+    rootPlugin: { foo: 'bar' }, // this should not be included in the diagnosis
   } as unknown as Config;
 
   afterEach(() => {
@@ -85,7 +87,10 @@ describe('Doctor Class', () => {
     expect(dr.getDiagnosis().pluginSpecificData).to.deep.equal(expectedEntry);
     dr.addPluginData(pluginName, dataEntries[1]);
     expectedEntry[pluginName] = [dataEntries[0], dataEntries[1]];
-    expect(dr.getDiagnosis().pluginSpecificData).to.deep.equal(expectedEntry);
+    const diagnosis = dr.getDiagnosis();
+    expect(diagnosis.pluginSpecificData).to.deep.equal(expectedEntry);
+    expect(diagnosis.cliConfig).to.not.have.property('_commandIDs');
+    expect(diagnosis.cliConfig).to.not.have.property('rootPlugin');
   });
 
   it('writes file names with doctor ID', async () => {


### PR DESCRIPTION
### What does this PR do?
omits `_commandIDs` and `rootPlugin` large fields from the doctor diagnosis since it bloats the diagnosis with data that isn't useful for the doctor command.

### What issues does this PR fix or reference?
@W-15040999@