### PR TITLE
fix: avoid nullish in template literal

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -249,7 +249,7 @@ ${this.doctor
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       cp.on('exit', async (code) => {
         this.doctor.setExitCode(code ?? 0);
-        await this.doctor.writeStdout(`\nCommand exit code: ${code}\n`);
+        await this.doctor.writeStdout(`\nCommand exit code: ${code ?? 'null'}\n`);
         this.doctor.closeStdout();
         this.doctor.closeStderr();
         this.filesWrittenMsgs.push(`Wrote command stdout log to: ${stdoutLogLocation}`);

--- a/src/commands/info/releasenotes/display.ts
+++ b/src/commands/info/releasenotes/display.ts
@@ -107,7 +107,7 @@ export default class Display extends SfCommand<DisplayOutput | undefined> {
         // --hook is passed in the post install/update scripts
         const { message, stack, name } = err as Error;
 
-        this.warn(`${this.id} failed: ${message}`);
+        this.warn(`${this.id ?? '<no command id>'} failed: ${message}`);
 
         logger.trace(stack);
         await Lifecycle.getInstance().emitTelemetry({
@@ -136,4 +136,4 @@ export default class Display extends SfCommand<DisplayOutput | undefined> {
 export type DisplayOutput = {
   body: string;
   url: string;
-}
+};

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -32,7 +32,11 @@ export type SfDoctor = {
   writeStdout(contents: string): Promise<boolean>;
 };
 
-type CliConfig = Partial<Interfaces.Config> & { nodeEngine: string };
+// oclif has some properties marked as optional in the Interface, but they will be present after Load() is called
+type CliConfig = Partial<Interfaces.Config> & { nodeEngine: string } & Pick<
+    Required<Interfaces.Config>,
+    'windows' | 'userAgent' | 'shell' | 'channel'
+  >;
 
 export type SfDoctorDiagnosis = {
   versionDetail: Omit<Interfaces.VersionDetails, 'pluginVersions'> & { pluginVersions: string[] };


### PR DESCRIPTION
### What does this PR do?
adjust types where oclif always has values, handle nullish literals

### What issues does this PR fix or reference?
https://github.com/forcedotcom/eslint-config-salesforce-typescript/actions/runs/9703130477/job/26780563575?pr=246