### PR TITLE
fix: no events without proxy env vars

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -207,18 +207,24 @@ export class Diagnostics {
     const httpsProxyEnvVarStatus = getStatus(httpsProxyEnvVars);
     const noProxyEnvVarStatus = getStatus(noProxyEnvVars);
 
-    await Lifecycle.getInstance().emit('Doctor:diagnostic', {
-      testName: 'http_proxy and HTTP_proxy environment variables match',
-      status: httpProxyEnvVarStatus,
-    });
-    await Lifecycle.getInstance().emit('Doctor:diagnostic', {
-      testName: 'https_proxy and HTTPS_PROXY environment variables match',
-      status: httpsProxyEnvVarStatus,
-    });
-    await Lifecycle.getInstance().emit('Doctor:diagnostic', {
-      testName: 'no_proxy and NO_PROXY environment variables match',
-      status: noProxyEnvVarStatus,
-    });
+    if (httpProxyEnvVars.length) {
+      await Lifecycle.getInstance().emit('Doctor:diagnostic', {
+        testName: 'http_proxy and HTTP_PROXY environment variables match',
+        status: httpProxyEnvVarStatus,
+      });
+    }
+    if (httpsProxyEnvVars.length) {
+      await Lifecycle.getInstance().emit('Doctor:diagnostic', {
+        testName: 'https_proxy and HTTPS_PROXY environment variables match',
+        status: httpsProxyEnvVarStatus,
+      });
+    }
+    if (noProxyEnvVars.length) {
+      await Lifecycle.getInstance().emit('Doctor:diagnostic', {
+        testName: 'no_proxy and NO_PROXY environment variables match',
+        status: noProxyEnvVarStatus,
+      });
+    }
 
     if (httpProxyEnvVarStatus === 'fail') {
       this.doctor.addSuggestion(messages.getMessage('matchProxyEnvVarSuggestion', ['http_proxy', 'HTTP_PROXY']));

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -109,7 +109,7 @@ describe('Diagnostics', () => {
       const diagnostics = new Diagnostics(dr, oclifConfig);
       await diagnostics.proxyEnvVarsCheck();
 
-      expect(lifecycleEmitSpy.callCount, 'Expected "Doctor:diagnostic" event fired 3 times').to.equal(3);
+      expect(lifecycleEmitSpy.callCount, 'Expected no "Doctor:diagnostic" event fired').to.equal(0);
       expect(drAddSuggestionSpy.called, 'Expected no suggestions to be added').to.be.false;
     });
 


### PR DESCRIPTION
### What does this PR do?
The proxy diagnostic tests are only run when the associated proxy env vars are set.

### What issues does this PR fix or reference?
@W-16510822@