### PR TITLE
fix: add warning when no proxy env vars are set

### DIFF
--- a/messages/diagnostics.md
+++ b/messages/diagnostics.md
@@ -22,3 +22,7 @@ Uninstall the deprecated Salesforce CLI (%s) version %s and install the @salesfo
 # matchProxyEnvVarSuggestion
 
 Modify the values for %s and %s environment variables to match.
+
+# noProxyEnvVarSet
+
+Warning: The CLI does not fully support the "no_proxy" and "NO_PROXY" environment variables and could cause connection issues when running commands.

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -224,6 +224,11 @@ export class Diagnostics {
         testName: 'no_proxy and NO_PROXY environment variables match',
         status: noProxyEnvVarStatus,
       });
+      await Lifecycle.getInstance().emit('Doctor:diagnostic', {
+        testName: 'no_proxy and/or NO_PROXY environment variables set',
+        status: 'warn',
+      });
+      this.doctor.addSuggestion(messages.getMessage('noProxyEnvVarSet'));
     }
 
     if (httpProxyEnvVarStatus === 'fail') {

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -128,8 +128,8 @@ describe('Diagnostics', () => {
       const diagnostics = new Diagnostics(dr, oclifConfig);
       await diagnostics.proxyEnvVarsCheck();
 
-      expect(lifecycleEmitSpy.callCount, 'Expected "Doctor:diagnostic" event fired 3 times').to.equal(3);
-      expect(drAddSuggestionSpy.called, 'Expected no suggestions to be added').to.be.false;
+      expect(lifecycleEmitSpy.callCount, 'Expected "Doctor:diagnostic" event fired 4 times').to.equal(4);
+      expect(drAddSuggestionSpy.callCount, 'Expected suggestion to be added for no_proxy').to.equal(1);
     });
 
     it('passes with proxy env vars in only lowercase', async () => {
@@ -144,8 +144,8 @@ describe('Diagnostics', () => {
       const diagnostics = new Diagnostics(dr, oclifConfig);
       await diagnostics.proxyEnvVarsCheck();
 
-      expect(lifecycleEmitSpy.callCount, 'Expected "Doctor:diagnostic" event fired 3 times').to.equal(3);
-      expect(drAddSuggestionSpy.called, 'Expected no suggestions to be added').to.be.false;
+      expect(lifecycleEmitSpy.callCount, 'Expected "Doctor:diagnostic" event fired 4 times').to.equal(4);
+      expect(drAddSuggestionSpy.callCount, 'Expected suggestion to be added for no_proxy').to.equal(1);
     });
 
     it('fails with non-matching proxy env vars', async () => {
@@ -163,8 +163,8 @@ describe('Diagnostics', () => {
       const diagnostics = new Diagnostics(dr, oclifConfig);
       await diagnostics.proxyEnvVarsCheck();
 
-      expect(lifecycleEmitSpy.callCount, 'Expected "Doctor:diagnostic" event fired 3 times').to.equal(3);
-      expect(drAddSuggestionSpy.callCount, 'Expected 3 suggestions to be added').to.equal(3);
+      expect(lifecycleEmitSpy.callCount, 'Expected "Doctor:diagnostic" event fired 4 times').to.equal(4);
+      expect(drAddSuggestionSpy.callCount, 'Expected 4 suggestions to be added').to.equal(4);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
adds a warning when no proxy env vars are set.  updates tests.

### What issues does this PR fix or reference?
@W-16510822@