### PR TITLE
 fix: set issue template to be used in URL W-18246767

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -128,7 +128,7 @@ export default class Doctor extends SfCommand<SfDoctorDiagnosis> {
         `https://github.com/forcedotcom/cli/issues/new?title=${title}&body=${this.generateIssueMarkdown(
           ghIssue.body,
           diagnosis
-        )}&labels=doctor,investigating,${this.config.bin}`
+        )}&labels=doctor,investigating,${this.config.bin}&template=bug_report`
       )
         // # were not encoding correctly from encodeURI to be parsed in the issue body
         .replace(/#/g, '%23');


### PR DESCRIPTION
### What does this PR do?

sets the issue template in the URL so it opens correctly

### What issues does this PR fix or reference?
@W-18246767@
https://github.com/forcedotcom/cli/issues/3264