### PR TITLE
fix: disable ANSI color seq for debug logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@inquirer/input": "^2.3.0",
     "@jsforce/jsforce-node": "^3.8.2",
     "@oclif/core": "^4",
-    "@salesforce/core": "^8.12.0",
+    "@salesforce/core": "^8.14.0",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/sf-plugins-core": "^12",
     "got": "^13.0.0",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -232,7 +232,16 @@ ${this.doctor
       const debugLogLocation = this.doctor.getDoctoredFilePath(join(this.outputDir, 'command-debug.log'));
       this.doctor.createStdoutWriteStream(stdoutLogLocation);
       this.doctor.createStderrWriteStream(debugLogLocation);
-      const cp = spawn(cmdString, [], { shell: true, env: Object.assign({}, process.env) });
+      const cp = spawn(cmdString, [], {
+        shell: true,
+        env: Object.assign(
+          {},
+          {
+            ...process.env,
+            SF_LOG_COLORIZE: 'false',
+          }
+        ),
+      });
 
       cp.on('error', (err) => {
         this.log(`Error executing command: ${err.message}`);

--- a/src/shared/getInfoConfig.ts
+++ b/src/shared/getInfoConfig.ts
@@ -13,7 +13,7 @@ export type PjsonWithInfo = {
   oclif: Interfaces.PJSON['oclif'] & {
     info: InfoConfig;
   };
-} & Interfaces.PJSON
+} & Interfaces.PJSON;
 
 export type InfoConfig = {
   releasenotes: {
@@ -21,7 +21,7 @@ export type InfoConfig = {
     releaseNotesPath: string;
     releaseNotesFilename: string;
   };
-}
+};
 
 /* sfdx example to add to cli pjson.oclif
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,10 +1677,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.10.0", "@salesforce/core@^8.11.0", "@salesforce/core@^8.11.1", "@salesforce/core@^8.12.0", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0":
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.12.0.tgz#a458cc3e39f4e7df57d94f0deaaa0fd0660b18c9"
-  integrity sha512-LJIjoQ3UQJ1r/xxdQcaG5bU8MfxeO/LJhrfK/7LZeHVtp1iOIgedbwPuVNzTzYciDWh8elborarrPM4uWjtu5g==
+"@salesforce/core@^8.10.0", "@salesforce/core@^8.11.0", "@salesforce/core@^8.11.1", "@salesforce/core@^8.14.0", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0":
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.14.0.tgz#fcdd8b641221fee668b95ed2ede56b251668077c"
+  integrity sha512-Ta1aY15TfgxLyFNNlkw60Mm3dDtiEb50TSp3/wzrbuMgkEGvFBEZQca/ChrjANXhpw8pURDUTzL4VV/1eGCHrQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.8.2"
     "@salesforce/kit" "^3.2.2"
@@ -2219,21 +2219,7 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@smithy/signature-v4@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.0.2.tgz#363854e946fbc5bc206ff82e79ada5d5c14be640"
-  integrity sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==
-  dependencies:
-    "@smithy/is-array-buffer" "^4.0.0"
-    "@smithy/protocol-http" "^5.1.0"
-    "@smithy/types" "^4.2.0"
-    "@smithy/util-hex-encoding" "^4.0.0"
-    "@smithy/util-middleware" "^4.0.2"
-    "@smithy/util-uri-escape" "^4.0.0"
-    "@smithy/util-utf8" "^4.0.0"
-    tslib "^2.6.2"
-
-"@smithy/signature-v4@^5.1.0":
+"@smithy/signature-v4@^5.0.2", "@smithy/signature-v4@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.1.0.tgz#2c56e5b278482b04383d84ea2c07b7f0a8eb8f63"
   integrity sha512-4t5WX60sL3zGJF/CtZsUQTs3UrZEDO2P7pEaElrekbLqkWPYkgqNW1oeiNYC6xXifBnT9dVBOnNQRvOE9riU9w==
@@ -4388,11 +4374,6 @@ faye@^1.4.0:
     safe-buffer "*"
     tough-cookie "*"
     tunnel-agent "*"
-
-fdir@^6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.2.tgz#ddaa7ce1831b161bc3657bb99cb36e1622702689"
-  integrity sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==
 
 fdir@^6.4.4:
   version "6.4.5"
@@ -7701,20 +7682,12 @@ tiny-jsonc@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-jsonc/-/tiny-jsonc-1.0.2.tgz#208df4c437684199cc724f31c2b91ee39c349678"
   integrity sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw==
 
-tinyglobby@^0.2.13:
+tinyglobby@^0.2.13, tinyglobby@^0.2.9:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.14.tgz#5280b0cf3f972b050e74ae88406c0a6a58f4079d"
   integrity sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==
   dependencies:
     fdir "^6.4.4"
-    picomatch "^4.0.2"
-
-tinyglobby@^0.2.9:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.10.tgz#e712cf2dc9b95a1f5c5bbd159720e15833977a0f"
-  integrity sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==
-  dependencies:
-    fdir "^6.4.2"
     picomatch "^4.0.2"
 
 tmp@^0.0.33:


### PR DESCRIPTION
### What does this PR do?
Disable ANSI color sequences when writing the commad-stdout log:
```
[16:52:24.322] [90mTRACE[39m (sf-startup): [36mCreated 'sf-startup' child logger instance[39m
[16:52:24.323] [90mTRACE[39m (sf:oclif:find-root:root-plugin): [36mCreated 'sf:oclif:find-root:root-plugin' child logger instance[39m
...
```


TODO:
* add test instructions, I think these changes don't work yet when linking the plugin because the top-level logger being passed is still using the old sfdx-core, should be tested with local sf repo and deduping core.

### What issues does this PR fix or reference?
